### PR TITLE
Add known bots to config.js

### DIFF
--- a/config.js
+++ b/config.js
@@ -77,14 +77,19 @@ const settings = {
         BOT_USERNAME,
         `blerp`,
         `buttsbot`,
+        `fossabot`,
+        `kofistreambot`,
         `moobot`,
         `nightbot`,
         `pokemoncommunitygame`,
         `sery_bot`,
         `soundalerts`,
+        `sport_scores_bot`,
         `streamelements`,
         `streamlabs`,
-        `undertalebot`
+        `undertalebot`,
+        `uwu_twanswator`,
+        `wizebot`
     ],
     baseEmotes: {
         lemonEmotes: [

--- a/config.js
+++ b/config.js
@@ -77,7 +77,10 @@ const settings = {
         BOT_USERNAME,
         `blerp`,
         `buttsbot`,
+        `commanderroot`,
+        `creatisbot`,
         `fossabot`,
+        `frostytoolsdotcom`,
         `kofistreambot`,
         `moobot`,
         `nightbot`,
@@ -87,6 +90,7 @@ const settings = {
         `sport_scores_bot`,
         `streamelements`,
         `streamlabs`,
+        `tangiabot`,
         `undertalebot`,
         `uwu_twanswator`,
         `wizebot`


### PR DESCRIPTION
Added a few other known bots to lemony's list.

(Debated adding capitalization for legibility, but wasn't sure if that would interfere with functionality.)

Future thoughts: would it be feasible/worth adding a per-channel "users to ignore" feature? Thinking of people who use custom bots (like TheTaraSHARK)